### PR TITLE
added option to set distribution address in cli "distributions add"

### DIFF
--- a/.changeset/chatty-yaks-visit.md
+++ b/.changeset/chatty-yaks-visit.md
@@ -1,0 +1,5 @@
+---
+"@peeramid-labs/sdk": patch
+---
+
+added option to set distribution address in cli "distributions add"

--- a/src/cli/commands/distributions/add.ts
+++ b/src/cli/commands/distributions/add.ts
@@ -18,6 +18,7 @@ function formatBytes32String(text: string): `0x${string}` {
 
 export const addCommand = new Command("add")
   .description("Add a new distribution")
+  .option("-a, --address <address>", "Address of the distribution")
   .option("-r, --rpc <url>", "RPC endpoint URL. If not provided, RPC_URL environment variable will be used")
   .option("-d, --distributor <address>", "Address of the distributor")
   .option("-i, --m-index <mnemonicIndex>", "Index to derive from mnemonic")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI option to specify a distribution address when using the "distributions add" command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->