### PR TITLE
Feat: Support custom chain IDs in CLI commands

### DIFF
--- a/.changeset/cool-spoons-behave.md
+++ b/.changeset/cool-spoons-behave.md
@@ -1,0 +1,5 @@
+---
+"@peeramid-labs/sdk": minor
+---
+
+enabled CLI usage outside of known chainIds

--- a/src/cli/commands/distributions/list.ts
+++ b/src/cli/commands/distributions/list.ts
@@ -9,6 +9,10 @@ export const listCommand = new Command("list")
   .description("List all distributions")
   .option("-r, --rpc <url>", "RPC endpoint URL. If not provided, RPC_URL environment variable will be used")
   .option(
+    "-d, --distributor <address>",
+    "Distributor address, or env DISTRIBUTOR_ADDRESS. If none provided, will attempt to resolve from known chainId artifacts"
+  )
+  .option(
     "-e, --envio <url>",
     "Envio GraphQL endpoint URL. If not provided, http://localhost:8080/v1/graphql will be used. Alternatively INDEXER_URL environment variable may be used",
     "http://localhost:8080/v1/graphql"
@@ -23,12 +27,16 @@ export const listCommand = new Command("list")
       console.log(`Chain ID: ${chainId}`);
       console.log(`Envio endpoint: ${process.env.INDEXER_URL ?? options.envio}`);
 
-      const maoDistributor = new MAODistributorClient(chainId, {
-        publicClient,
-        envioClient: new EnvioGraphQLClient({
-          endpoint: process.env.INDEXER_URL ?? options.envio,
-        }),
-      });
+      const maoDistributor = new MAODistributorClient(
+        chainId,
+        {
+          publicClient,
+          envioClient: new EnvioGraphQLClient({
+            endpoint: process.env.INDEXER_URL ?? options.envio,
+          }),
+        },
+        options.distributor || process.env.DISTRIBUTOR_ADDRESS
+      );
 
       spinner.text = "Fetching distributions...";
       const distributions = await maoDistributor.getDistributions();

--- a/src/cli/commands/distributions/remove.ts
+++ b/src/cli/commands/distributions/remove.ts
@@ -12,6 +12,10 @@ export const removeCommand = new Command("remove")
   .option("-n, --name <name>", "Name of the distribution")
   .option("-r, --rpc <url>", "RPC endpoint URL. If not provided, RPC_URL environment variable will be used")
   .option(
+    "-d, --distributor <address>",
+    "Distributor address, or env DISTRIBUTOR_ADDRESS. If none provided, will attempt to resolve from known chainId artifacts"
+  )
+  .option(
     "-e, --envio <url>",
     "Envio GraphQL endpoint URL. If not provided, http://localhost:8080/v1/graphql will be used. Alternatively INDEXER_URL environment variable may be used",
     "http://localhost:8080/v1/graphql"
@@ -24,13 +28,17 @@ export const removeCommand = new Command("remove")
       const walletClient = await createWallet(options.rpc, options.key);
       const chainId = Number(await publicClient.getChainId());
 
-      const maoDistributor = new MAODistributorClient(chainId, {
-        publicClient,
-        walletClient,
-        envioClient: new EnvioGraphQLClient({
-          endpoint: process.env.INDEXER_URL ?? options.envio,
-        }),
-      });
+      const maoDistributor = new MAODistributorClient(
+        chainId,
+        {
+          publicClient,
+          walletClient,
+          envioClient: new EnvioGraphQLClient({
+            endpoint: process.env.INDEXER_URL ?? options.envio,
+          }),
+        },
+        options.distributor || process.env.DISTRIBUTOR_ADDRESS
+      );
 
       spinner.stop();
       if (!options.name && !options.id) {

--- a/src/cli/commands/distributions/state.ts
+++ b/src/cli/commands/distributions/state.ts
@@ -10,6 +10,10 @@ export const stateCommand = new Command("state")
   .description("Get the state of a distribution")
   .option("-r, --rpc <url>", "RPC endpoint URL. If not provided, RPC_URL environment variable will be used")
   .option(
+    "-d, --distributor <address>",
+    "Distributor address, or env DISTRIBUTOR_ADDRESS. If none provided, will attempt to resolve from known chainId artifacts"
+  )
+  .option(
     "-e, --envio <url>",
     "Envio GraphQL endpoint URL. If not provided, http://localhost:8080/v1/graphql will be used. Alternatively INDEXER_URL environment variable may be used",
     "http://localhost:8080/v1/graphql"
@@ -21,13 +25,17 @@ export const stateCommand = new Command("state")
     const walletClient = await createWallet(options.rpc, options.key);
     const chainId = Number(await publicClient.getChainId());
 
-    const maoDistributor = new MAODistributorClient(chainId, {
-      publicClient,
-      walletClient,
-      envioClient: new EnvioGraphQLClient({
-        endpoint: process.env.INDEXER_URL ?? options.envio,
-      }),
-    });
+    const maoDistributor = new MAODistributorClient(
+      chainId,
+      {
+        publicClient,
+        walletClient,
+        envioClient: new EnvioGraphQLClient({
+          endpoint: process.env.INDEXER_URL ?? options.envio,
+        }),
+      },
+      options.distributor || process.env.DISTRIBUTOR_ADDRESS
+    );
 
     const owner = await publicClient.readContract({
       address: maoDistributor.address,

--- a/src/cli/commands/instances/list.ts
+++ b/src/cli/commands/instances/list.ts
@@ -15,6 +15,10 @@ export const listCommand = new Command("list")
     "Envio GraphQL endpoint URL. If not provided, http://localhost:8080/v1/graphql will be used. Alternatively INDEXER_URL environment variable may be used",
     "http://localhost:8080/v1/graphql"
   )
+  .option(
+    "-d, --distributor-address <address>",
+    "Distributor address, or env DISTRIBUTOR_ADDRESS. If none provided, will attempt to resolve from known chainId artifacts"
+  )
   .action(async (options) => {
     const spinner = ora("Initializing client...").start();
 
@@ -22,13 +26,17 @@ export const listCommand = new Command("list")
       const publicClient = await createPublic(options.rpc);
       const chainId = Number(await publicClient.getChainId());
 
-      const maoDistributor = new MAODistributorClient(chainId, {
-        publicClient,
-        address: options.address && getAddress(options.address),
-        envioClient: new EnvioGraphQLClient({
-          endpoint: process.env.INDEXER_URL ?? options.envio,
-        }),
-      });
+      const maoDistributor = new MAODistributorClient(
+        chainId,
+        {
+          publicClient,
+          address: options.address && getAddress(options.address),
+          envioClient: new EnvioGraphQLClient({
+            endpoint: process.env.INDEXER_URL ?? options.envio,
+          }),
+        },
+        options.distributorAddress || process.env.DISTRIBUTOR_ADDRESS
+      );
 
       spinner.text = "Fetching instances...";
       const distributions = await maoDistributor.getDistributions();

--- a/src/cli/commands/playbook.ts
+++ b/src/cli/commands/playbook.ts
@@ -5,7 +5,10 @@ import { exec } from "child_process";
 
 export const playbookCommand = new Command("playbook")
   .description("Execute playbook scripts from the playbooks folder")
-  .argument("<playbook-name>", "Name of the playbook to execute (without .sh extension)")
+  .argument(
+    "<playbook-name>",
+    "Name of the playbook to execute (without .sh extension; Available playbooks: demo-script, partial-voting)"
+  )
   .option("-f, --fellowship-id <id>", "Fellowship ID", "1")
   .option("-g, --game-id <id>", "Game ID", "1")
   .option("--run-to-turn <turn>", "Run up to this turn number")

--- a/src/rankify/MAODistributor.ts
+++ b/src/rankify/MAODistributor.ts
@@ -127,9 +127,9 @@ export class MAODistributorClient extends DistributorClient {
       walletClient?: WalletClient;
       address?: Address;
       envioClient: EnvioGraphQLClient;
-    }
+    },
+    address: Address = getArtifact(chainId, "DAODistributor").address
   ) {
-    const { address } = getArtifact(chainId, "DAODistributor");
     super({
       address: client.address ?? getAddress(address),
       publicClient: client.publicClient,
@@ -425,13 +425,13 @@ export class MAODistributorClient extends DistributorClient {
       });
       const chainid = this.publicClient?.chain?.id;
       if (!chainid) throw new Error("No chain id found");
-      const RankifyTokenBalance = await this.publicClient.readContract({
-        abi: RankifyAbi,
+      const balance = await this.publicClient.readContract({
+        abi: erc20Abi,
         functionName: "balanceOf",
-        address: getArtifact(chainid, "Rankify").address,
+        address: paymentToken,
         args: [this.walletClient.account?.address],
       });
-      logger(`Rankify Token Balance ${RankifyTokenBalance.toString()}`);
+      logger(`Balance ${balance.toString()}`);
       logger(`Allowance ${allowance.toString()} for ${this.walletClient.account?.address} on ${this.address}`);
       return allowance < (await this.getInstantiatePrice(distributorsId));
     } catch (e) {

--- a/src/rankify/Player.ts
+++ b/src/rankify/Player.ts
@@ -75,8 +75,8 @@ export default class RankifyPlayer extends InstanceBase {
    * @returns A promise that resolves when the tokens are approved
    * @throws If the account is not found or the tokens cannot be approved
    */
-  approveTokensIfNeeded = async (value: bigint) => {
-    const tokenContract = getContract(this.chainId, "Rankify", this.walletClient);
+  approveTokensIfNeeded = async (value: bigint, overrideArtifact?: { address: Address; pathOverride: string }) => {
+    const tokenContract = getContract(this.chainId, "Rankify", this.walletClient, overrideArtifact);
     if (!this.walletClient.account?.address) throw new Error("Account not found");
     if (value > 0n) {
       try {

--- a/src/utils/ApiError.ts
+++ b/src/utils/ApiError.ts
@@ -55,8 +55,26 @@ export async function handleRPCError(e: unknown) {
       const _revertError = revertError as ContractFunctionExecutionError;
       const errorName = _revertError?.name;
       if (!errorName) {
-        const cause = _revertError.cause as { signature?: string };
-        if (cause?.signature) {
+        try {
+          const cause = _revertError?.cause as { signature?: string };
+          if (cause?.signature) {
+            const remoteAttempt = fetch(
+              `https://www.4byte.directory/api/v1/signatures/?hex_signature=${cause.signature}`
+            );
+            const response = await remoteAttempt;
+            const data = await response.json();
+            return new Error(data.results[0].text_signature);
+          } else return e;
+        } catch (error) {
+          console.warn(_revertError); //This happens if RPC error returns schema that breaks validation expected by viem
+          return _revertError;
+        }
+      }
+    }
+    if (revertError instanceof CallExecutionError) {
+      try {
+        const cause = revertError.cause.cause as { signature?: string };
+        if (!e.name) {
           const remoteAttempt = fetch(
             `https://www.4byte.directory/api/v1/signatures/?hex_signature=${cause.signature}`
           );
@@ -64,16 +82,10 @@ export async function handleRPCError(e: unknown) {
           const data = await response.json();
           return new Error(data.results[0].text_signature);
         } else return e;
+      } catch (error) {
+        console.warn(error);
+        return revertError;
       }
-    }
-    if (revertError instanceof CallExecutionError) {
-      const cause = revertError.cause.cause as { signature?: string };
-      if (!e.name) {
-        const remoteAttempt = fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${cause.signature}`);
-        const response = await remoteAttempt;
-        const data = await response.json();
-        return new Error(data.results[0].text_signature);
-      } else return e;
     }
     const cause = e?.cause as { signature?: string };
     if (cause?.signature) {

--- a/src/utils/artifacts.ts
+++ b/src/utils/artifacts.ts
@@ -66,7 +66,6 @@ export const getArtifact = (
     logs: Log<bigint, number, false>[];
   };
 } => {
-  const chainPath = overrideChainName ?? getChainPath(chainId);
   if (artifactName === "CodeIndex") {
     return {
       abi: ERC7744Abi,
@@ -81,6 +80,7 @@ export const getArtifact = (
       },
     };
   }
+  const chainPath = overrideChainName ?? getChainPath(chainId);
   const artifact = (
     artifactName === "Multipass"
       ? require(`@peeramid-labs/multipass/deployments/${chainPath}/${artifactName}.json`)
@@ -120,11 +120,15 @@ export const getArtifact = (
 export const getContract = <TArtifactName extends ArtifactTypes, TClient extends PublicClient | WalletClient>(
   chainId: number,
   artifactName: TArtifactName,
-  client: TClient
+  client: TClient,
+  overrideArtifact?: {
+    address: Address;
+    pathOverride: string;
+  }
 ): GetContractReturnType<ArtifactAbi[TArtifactName], TClient> => {
-  const artifact = getArtifact(chainId, artifactName);
+  const artifact = getArtifact(chainId, artifactName, overrideArtifact && overrideArtifact.pathOverride);
   return viemGetContract({
-    address: artifact.address,
+    address: overrideArtifact ? overrideArtifact.address : artifact.address,
     abi: artifact.abi,
     client,
   }) as GetContractReturnType<ArtifactAbi[TArtifactName], TClient>;

--- a/src/utils/chainMapping.ts
+++ b/src/utils/chainMapping.ts
@@ -10,7 +10,7 @@ export const chainToPath: ChainMapping = {
 export function getChainPath(chainId: number): string {
   const path = chainToPath[chainId.toString() as keyof typeof chainToPath];
   if (!path) {
-    throw new Error(`Chain ID ${chainId} is not supported`);
+    return "Custom network";
   }
   return path;
 }


### PR DESCRIPTION
Introduce `--distributor` and `--distributor-address` options in CLI commands to explicitly specify contract addresses. This enables use of the CLI on chains not present in the SDK's default artifact mappings.

Relax artifact lookup and contract instantiation to allow manual overrides when default artifacts are unavailable. Update `getChainPath` to return "Custom network" for unknown chain IDs, preventing errors. Also enhance RPC error parsing for better debugging.